### PR TITLE
Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 rvm:
   - 2.5.3
 
-jdk: 'oraclejdk8'
+jdk: 'openjdk8'
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ TODO
     - `authority`: search by exact authority string
     - `uri`: search by exact uri string
     - `pref_label`: search by exact pref_label string
-    - `alt_label`: search by exact alt_label string
+    - `alt_labels`: search by exact alt_labels string
     - `term_type`: search by exact term_type
     - additionally you will be able to query by any custom field name defined in that vocabulary, for example, if a custom field name is `name_type`, doing the following search would search through the terms in that vocabulary for any terms that contain 'personal' in the name_type field. If a `name_type` field is not defined within that vocabulary you will get no results.
       `GET /vocabularies/:string_key/terms?name_type=personal`
@@ -355,7 +355,7 @@ This endpoint will help define the terms returned and should help in the creatin
           "type": "string"
           "title": "Issue title."
         },
-        "alt_label": {
+        "alt_labels": {
           "type": "array",
   	  "items": { "type": "string" },
   	  "title": "Alternate Label",

--- a/app/controllers/v1/custom_fields_controller.rb
+++ b/app/controllers/v1/custom_fields_controller.rb
@@ -3,13 +3,13 @@ module V1
     before_action :valid_vocabulary?, :field_key_present?
 
     def create
-      if vocabulary.custom_fields.key?(params[:field_key])
+      if vocabulary.custom_fields.key?(create_params[:field_key])
         render json: URIService::JSON.errors('Field key already exists'), status: 409
       else
         vocabulary.add_custom_field(create_params)
 
         if vocabulary.save
-          render json: URIService::JSON.custom_field(vocabulary, params[:field_key]), status: 201
+          render json: URIService::JSON.custom_field(vocabulary, create_params[:field_key]), status: 201
         else
           render json: URIService::JSON.errors(vocabulary.errors.full_messages), status: 400
         end
@@ -47,17 +47,17 @@ module V1
     private
 
       def field_key_present?
-        if params.fetch(:field_key, nil).blank?
+        if (action_name == 'create' ? params.dig(:custom_field, :field_key) : params.fetch(:field_key, nil)).blank?
           render json: URIService::JSON.errors('Field key must be present.'), status: 400
         end
       end
 
       def create_params
-        params.permit(:field_key, :label, :data_type)
+        params.require(:custom_field).permit(:field_key, :label, :data_type)
       end
 
       def update_params
-        params.permit(:field_key, :label)
+        params.require(:custom_field).permit(:label).to_h.merge(field_key: params[:field_key])
       end
   end
 end

--- a/app/controllers/v1/open_api_specification_controller.rb
+++ b/app/controllers/v1/open_api_specification_controller.rb
@@ -121,7 +121,7 @@ module V1
                     required: true
 
           parameter name: :pref_label, in: :query, type: :string
-          parameter name: :alt_label, in: :query, type: :array,
+          parameter name: :alt_labels, in: :query, type: :array,
                     items: { type: :string }
           parameter name: :authority, in: :query, type: :string
           parameter name: :term_type, in: :query, type: :string
@@ -138,7 +138,7 @@ module V1
           parameter name: :pref_label, in: :query, type: :string,
                     required: true
 
-          parameter name: :alt_label, in: :query, type: :array,
+          parameter name: :alt_labels, in: :query, type: :array,
                     'x-uri-service-only-for-term-type': ['external', 'local'],
                     items: { type: :string }
 
@@ -164,7 +164,7 @@ module V1
         operation :patch do
           parameter name: :uri, in: :path, type: :string, required: true
           parameter name: :pref_label, in: :query, type: :string
-          parameter name: :alt_label, in: :query, type: :array,
+          parameter name: :alt_labels, in: :query, type: :array,
                     'x-uri-service-only-for-term-type': ['external', 'local'],
                     items: { type: :string }
           parameter name: :authority, in: :query, type: :string

--- a/app/controllers/v1/terms_controller.rb
+++ b/app/controllers/v1/terms_controller.rb
@@ -45,8 +45,8 @@ module V1
       term.vocabulary = vocabulary
 
       custom_fields.each do |f, v|
-        next unless params.key?(f)
-        term.set_custom_field(f, params[f])
+        next unless params[:term].key?(f)
+        term.set_custom_field(f, params[:term][f])
       end
 
       if term.save
@@ -67,8 +67,8 @@ module V1
         term.assign_attributes(update_params) # updates, but doesn't save.
 
         custom_fields.each do |f, v|
-          next unless params.key?(f)
-          term.set_custom_field(f, params[f])
+          next unless params[:term].key?(f)
+          term.set_custom_field(f, params[:term][f])
         end
 
         if term.save
@@ -127,11 +127,11 @@ module V1
       end
 
       def create_params
-        params.permit(:pref_label, :uri, :authority, :term_type, :uuid, alt_label: [])
+        params.require(:term).permit(:pref_label, :uri, :authority, :term_type, :uuid, alt_label: [])
       end
 
       def update_params
-        params.permit(:pref_label, :authority, alt_label: [])
+        params.require(:term).permit(:pref_label, :authority, alt_label: [])
       end
   end
 end

--- a/app/controllers/v1/terms_controller.rb
+++ b/app/controllers/v1/terms_controller.rb
@@ -11,7 +11,7 @@ module V1
           solr_params.authority  params[:authority]
           solr_params.uri        params[:uri]
           solr_params.pref_label params[:pref_label]
-          solr_params.alt_label  params[:alt_label]
+          solr_params.alt_labels params[:alt_labels]
           solr_params.term_type  params[:term_type]
           solr_params.pagination per_page, page
 
@@ -116,7 +116,7 @@ module V1
         # the request. Something to look into in the future.
         valid_params = [
           'action', 'controller', 'format', 'vocabulary_string_key', 'q', 'uri',
-          'authority', 'pref_label', 'alt_label', 'term_type', 'per_page', 'page', 'term'
+          'authority', 'pref_label', 'alt_labels', 'term_type', 'per_page', 'page', 'term'
         ].concat(custom_fields.keys)
         Rails.logger.debug params.keys
         params.keys.all? { |i| valid_params.include?(i) }
@@ -127,11 +127,11 @@ module V1
       end
 
       def create_params
-        params.require(:term).permit(:pref_label, :uri, :authority, :term_type, :uuid, alt_label: [])
+        params.require(:term).permit(:pref_label, :uri, :authority, :term_type, :uuid, alt_labels: [])
       end
 
       def update_params
-        params.require(:term).permit(:pref_label, :authority, alt_label: [])
+        params.require(:term).permit(:pref_label, :authority, alt_labels: [])
       end
   end
 end

--- a/app/controllers/v1/vocabularies_controller.rb
+++ b/app/controllers/v1/vocabularies_controller.rb
@@ -60,11 +60,11 @@ module V1
     private
 
       def create_params
-        params.permit(:string_key, :label)
+        params.require(:vocabulary).permit(:string_key, :label)
       end
 
       def update_params
-        params.permit(:label)
+        params.require(:vocabulary).permit(:label)
       end
   end
 end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -18,19 +18,19 @@ class Term < ApplicationRecord
                    if: Proc.new { |t| t.uri? && (t.term_type == LOCAL || t.term_type == EXTERNAL) }
   validates :uri_hash, uniqueness: { scope: :vocabulary, message: 'unique check failed. This uri already exists in this vocabulary.' }
   validates :uuid, format: { with: /\A\h{8}-\h{4}-4\h{3}-[89ab]\h{3}-\h{12}\z/ }, allow_nil: true
-  validates :alt_label, absence: { message: 'is not allowed for temporary terms' }, if: Proc.new { |t| t.term_type == TEMPORARY }
+  validates :alt_labels, absence: { message: 'is not allowed for temporary terms' }, if: Proc.new { |t| t.term_type == TEMPORARY }
   validate  :uuid_uri_and_term_type_unchanged, :pref_label_unchanged_for_temp_term, :validate_custom_fields
 
   store :custom_fields, coder: JSON
 
-  serialize :alt_label, Array
+  serialize :alt_labels, Array
 
   def to_solr
     {
       'uuid'          => uuid,
       'uri'           => uri,
       'pref_label'    => pref_label,
-      'alt_label'     => alt_label,
+      'alt_labels'    => alt_labels,
       'term_type'     => term_type,
       'vocabulary'    => vocabulary.string_key,
       'authority'     => authority,

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -1,7 +1,7 @@
 class Vocabulary < ApplicationRecord
   ALPHANUMERIC_UNDERSCORE_KEY_REGEX = /\A[a-z]+[a-z0-9_]*\z/
   RESERVED_FIELD_NAMES = %w(
-    pref_label alt_label uri uri_hash vocabulary vocabulary_id,
+    pref_label alt_labels uri uri_hash vocabulary vocabulary_id,
     authority term_type custom_fields uuid created_at updated_at
   ).freeze
   DATA_TYPES = %w(string integer boolean).freeze

--- a/db/migrate/20190726151156_change_alt_label_column_name.rb
+++ b/db/migrate/20190726151156_change_alt_label_column_name.rb
@@ -1,0 +1,5 @@
+class ChangeAltLabelColumnName < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :terms, :alt_label, :alt_labels
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_14_155305) do
+ActiveRecord::Schema.define(version: 2019_07_26_151156) do
 
   create_table "terms", force: :cascade do |t|
     t.integer "vocabulary_id", null: false
     t.string "pref_label", null: false
-    t.text "alt_label"
+    t.text "alt_labels"
     t.string "uri", null: false
     t.string "uri_hash", null: false
     t.string "authority"

--- a/lib/uri_service/json.rb
+++ b/lib/uri_service/json.rb
@@ -20,7 +20,7 @@ module URIService
     def self.term(obj, request: true)
       output = nil
       if obj.is_a? Term
-        output = obj.as_json(only: [:uuid, :uri, :pref_label, :alt_label, :authority, :term_type])
+        output = obj.as_json(only: [:uuid, :uri, :pref_label, :alt_labels, :authority, :term_type])
 
         if obj.vocabulary
           obj.vocabulary.custom_fields.each { |f, _| output[f] = obj.custom_fields.fetch(f, nil) }
@@ -32,7 +32,7 @@ module URIService
           uuid:       document.fetch(:uuid, nil),
           uri:        document.fetch(:uri, nil),
           pref_label: document.fetch(:pref_label, nil),
-          alt_label:  document.fetch(:alt_label, []),
+          alt_labels: document.fetch(:alt_labels, []),
           authority:  document.fetch(:authority, nil),
           term_type:  document.fetch(:term_type, nil)
         }

--- a/lib/uri_service/solr_params.rb
+++ b/lib/uri_service/solr_params.rb
@@ -27,7 +27,7 @@ module URIService
       self
     end
 
-    [:vocabulary, :authority, :uri, :pref_label, :alt_label, :term_type].each do |term_attribute|
+    [:vocabulary, :authority, :uri, :pref_label, :alt_labels, :term_type].each do |term_attribute|
       define_method term_attribute do |value|
         fq(term_attribute.to_s, value)
       end

--- a/spec/fixtures/solr_cores/uri_service_solr6/conf/schema.xml
+++ b/spec/fixtures/solr_cores/uri_service_solr6/conf/schema.xml
@@ -12,7 +12,7 @@
   <field name="uuid"          type="string" stored="true" indexed="true" multiValued="false" required="true"/>
   <field name="uri"           type="string" stored="true" indexed="true" multiValued="false" required="true"/>
   <field name="pref_label"    type="string" stored="true" indexed="true" multiValued="false" required="true"/>
-  <field name="alt_label"     type="string" stored="true" indexed="true" multiValued="true"  required="false"/>
+  <field name="alt_labels"    type="string" stored="true" indexed="true" multiValued="true"  required="false"/>
   <field name="vocabulary"    type="string" stored="true" indexed="true" multiValued="false" required="true"/>
   <field name="term_type"     type="string" stored="true" indexed="true" multiValued="false" required="true"/>
   <field name="authority"     type="string" stored="true" indexed="true" multiValued="false" required="false"/>
@@ -71,9 +71,9 @@
   <copyField source="pref_label" dest="pref_label_suggest" />
   <copyField source="pref_label" dest="pref_label_suggest_edge" />
   <copyField source="pref_label" dest="pref_label_suggest_ngram" />
-  <copyField source="alt_label" dest="alt_label_suggest" />
-  <copyField source="alt_label" dest="alt_label_suggest_edge" />
-  <copyField source="alt_label" dest="alt_label_suggest_ngram" />
+  <copyField source="alt_labels" dest="alt_labels_suggest" />
+  <copyField source="alt_labels" dest="alt_labels_suggest_edge" />
+  <copyField source="alt_labels" dest="alt_labels_suggest_ngram" />
   <!-- sort copyFields -->
   <copyField source="pref_label" dest="pref_label_ssort" />
 

--- a/spec/fixtures/solr_cores/uri_service_solr6/conf/solrconfig.xml
+++ b/spec/fixtures/solr_cores/uri_service_solr6/conf/solrconfig.xml
@@ -824,8 +824,8 @@
       <str name="defType">edismax</str>
       <str name="q.alt">*:*</str>
       <str name="rows">10</str>
-      <str name="qf">pref_label_suggest^40 pref_label_suggest_ngram^30 alt_label_suggest^20 alt_label_suggest_ngram^10</str>
-      <str name="pf">pref_label_suggest_edge^40.0 alt_label_suggest_edge^30.0</str>
+      <str name="qf">pref_label_suggest^40 pref_label_suggest_ngram^30 alt_labels_suggest^20 alt_labels_suggest_ngram^10</str>
+      <str name="pf">pref_label_suggest_edge^40.0 alt_labels_suggest_edge^30.0</str>
       <str name="sort">score desc,pref_label_ssort asc</str>
       <str name="fl">
         *,
@@ -843,7 +843,7 @@
        <str name="defType">edismax</str>
        <str name="q.alt">*:*</str>
        <int name="rows">10</int>
-       <str name="qf">pref_label alt_label</str>
+       <str name="qf">pref_label alt_labels</str>
      </lst>
     <!-- In addition to defaults, "appends" params can be specified
          to identify values which should be appended to the list of

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -112,12 +112,12 @@ RSpec.describe Term, type: :model do
       expect(term.uuid).not_to be blank?
     end
 
-    context 'when alt_label is set' do
-      let(:term) { FactoryBot.build(:temp_term, alt_label: ['Big Foot']) }
+    context 'when alt_labels is set' do
+      let(:term) { FactoryBot.build(:temp_term, alt_labels: ['Big Foot']) }
 
       it 'returns validation error' do
         expect(term.save).to be false
-        expect(term.errors.full_messages).to include 'Alt label is not allowed for temporary terms'
+        expect(term.errors.full_messages).to include 'Alt labels is not allowed for temporary terms'
       end
     end
 
@@ -303,8 +303,8 @@ RSpec.describe Term, type: :model do
     end
 
     it 'updates solr document' do
-      term.update(alt_label: ['new_label'])
-      expect(term_solr_doc).to include('alt_label' => ['new_label'])
+      term.update(alt_labels: ['new_label'])
+      expect(term_solr_doc).to include('alt_labels' => ['new_label'])
     end
 
     context 'of a temporary term' do

--- a/spec/requests/v1/custom_fields_spec.rb
+++ b/spec/requests/v1/custom_fields_spec.rb
@@ -9,12 +9,18 @@ RSpec.describe 'Custom Fields Requests', type: :request do
     context 'when adding a new custom field' do
       before do
         post_with_auth "/api/v1/vocabularies/#{vocabulary.string_key}/custom_fields",
-             params: { field_key: 'harry_potter_reference', label: 'Harry Potter Reference', data_type: 'boolean' }
+             params: { custom_field: { field_key: 'harry_potter_reference', label: 'Harry Potter Reference', data_type: 'boolean' } }
       end
 
       it 'returns custom field' do
         expect(response.body).to be_json_eql(%(
-          { "field_key": "harry_potter_reference", "data_type": "boolean", "label": "Harry Potter Reference" }
+          {
+            "custom_field": {
+              "field_key": "harry_potter_reference",
+              "data_type": "boolean",
+              "label": "Harry Potter Reference"
+            }
+          }
         ))
       end
 
@@ -36,7 +42,7 @@ RSpec.describe 'Custom Fields Requests', type: :request do
         vocabulary.save
 
         post_with_auth "/api/v1/vocabularies/#{vocabulary.string_key}/custom_fields",
-             params: { field_key: 'harry_potter_reference', label: 'Harry Potter Reference', data_type: 'string' }
+             params: { custom_field: { field_key: 'harry_potter_reference', label: 'Harry Potter Reference', data_type: 'string' } }
       end
 
       it 'returns error' do
@@ -60,7 +66,7 @@ RSpec.describe 'Custom Fields Requests', type: :request do
     context 'when adding a custom field without a data type' do
       before do
         post_with_auth "/api/v1/vocabularies/#{vocabulary.string_key}/custom_fields",
-             params: { field_key: 'harry_potter_reference', label: 'Harry Potter Reference' }
+             params: { custom_field: { field_key: 'harry_potter_reference', label: 'Harry Potter Reference' } }
       end
 
       it 'returns error' do
@@ -87,7 +93,7 @@ RSpec.describe 'Custom Fields Requests', type: :request do
     context 'when adding a custom field that uses a reserved field name' do
       before do
         post_with_auth "/api/v1/vocabularies/#{vocabulary.string_key}/custom_fields",
-             params: { field_key: 'term_type', label: 'Harry Potter Reference', data_type: 'boolean' }
+             params: { custom_field: { field_key: 'term_type', label: 'Harry Potter Reference', data_type: 'boolean' } }
       end
 
       it 'returns error' do
@@ -109,7 +115,7 @@ RSpec.describe 'Custom Fields Requests', type: :request do
     context 'when adding custom field to vocabulary that doesn\'t exist' do
       before do
         post_with_auth '/api/v1/vocabularies/invalid/custom_fields',
-             params: { field_key: 'harry_potter_reference', label: 'Harry Potter Reference', data_type: 'boolean' }
+             params: { custom_field: { field_key: 'harry_potter_reference', label: 'Harry Potter Reference', data_type: 'boolean' } }
       end
 
       it 'returns error' do
@@ -126,7 +132,7 @@ RSpec.describe 'Custom Fields Requests', type: :request do
     context 'when adding a custom field without a field_key' do
       before do
         post_with_auth "/api/v1/vocabularies/#{vocabulary.string_key}/custom_fields",
-             params: { label: 'Harry Potter Reference', data_type: 'boolean' }
+             params: { custom_field: { label: 'Harry Potter Reference', data_type: 'boolean' } }
       end
 
       it 'returns error' do
@@ -150,15 +156,17 @@ RSpec.describe 'Custom Fields Requests', type: :request do
         vocabulary.save
 
         patch_with_auth "/api/v1/vocabularies/#{vocabulary.string_key}/custom_fields/harry_potter_reference",
-              params: { label: 'Wizarding World Reference' }
+              params: { custom_field: { label: 'Wizarding World Reference' } }
       end
 
       it 'returns custom field' do
         expect(response.body).to be_json_eql(%(
           {
-            "field_key": "harry_potter_reference",
-            "label": "Wizarding World Reference",
-            "data_type": "boolean"
+            "custom_field": {
+              "field_key": "harry_potter_reference",
+              "label": "Wizarding World Reference",
+              "data_type": "boolean"
+            }
           }
         ))
       end
@@ -181,7 +189,7 @@ RSpec.describe 'Custom Fields Requests', type: :request do
         vocabulary.save
 
         patch_with_auth "/api/v1/vocabularies/#{vocabulary.string_key}/custom_fields/harry_potter_reference",
-              params: { label: '' }
+              params: { custom_field: { label: '' } }
       end
 
       it 'returns 400' do
@@ -203,7 +211,7 @@ RSpec.describe 'Custom Fields Requests', type: :request do
     context 'when updating custom field that does not exist' do
       before do
         patch_with_auth "/api/v1/vocabularies/#{vocabulary.string_key}/custom_fields/harry_potter_reference",
-              params: { label: 'Wizarding World Reference' }
+              params: { custom_field: { label: 'Wizarding World Reference' } }
       end
 
       it 'returns error' do

--- a/spec/requests/v1/term_crud_spec.rb
+++ b/spec/requests/v1/term_crud_spec.rb
@@ -32,13 +32,15 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
       it 'returns one term' do
         expect(response.body).to be_json_eql(%(
           {
-            "uri": "http://id.worldcat.org/fast/1161301/",
-            "pref_label": "Unicorns",
-            "alt_label": [],
-            "authority": "fast",
-            "term_type": "external",
-            "classification": "Horse",
-            "harry_potter_reference": null
+            "term": {
+              "uri": "http://id.worldcat.org/fast/1161301/",
+              "pref_label": "Unicorns",
+              "alt_label": [],
+              "authority": "fast",
+              "term_type": "external",
+              "classification": "Horse",
+              "harry_potter_reference": null
+            }
           }
         )).excluding('uuid')
       end
@@ -79,11 +81,13 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
     context 'when successfully creating a new external term' do
       before do
         post_with_auth '/api/v1/vocabularies/mythical_creatures/terms', params: {
-          pref_label: 'Minotaur (Greek mythological character)',
-          uri: 'http://id.worldcat.org/fast/1023481',
-          authority: 'fast',
-          term_type: 'external',
-          classification: 'Human'
+          term: {
+            pref_label: 'Minotaur (Greek mythological character)',
+            uri: 'http://id.worldcat.org/fast/1023481',
+            authority: 'fast',
+            term_type: 'external',
+            classification: 'Human'
+          }
         }
       end
 
@@ -94,15 +98,17 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
 
       it 'returns newly created term in json' do
         expect(response.body).to be_json_eql(%(
-         {
-           "pref_label": "Minotaur (Greek mythological character)",
-           "alt_label": [],
-           "uri": "http://id.worldcat.org/fast/1023481",
-           "authority": "fast",
-           "term_type": "external",
-           "classification": "Human",
-           "harry_potter_reference": null
-         }
+          {
+            "term": {
+              "pref_label": "Minotaur (Greek mythological character)",
+              "alt_label": [],
+              "uri": "http://id.worldcat.org/fast/1023481",
+              "authority": "fast",
+              "term_type": "external",
+              "classification": "Human",
+              "harry_potter_reference": null
+            }
+          }
         )).excluding('uuid')
       end
 
@@ -114,10 +120,12 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
     context 'when successfully creating a new local term' do
       before do
         post_with_auth '/api/v1/vocabularies/mythical_creatures/terms', params: {
-          pref_label: 'Hippogriff',
-          alt_label: ['Hippogryph'],
-          term_type: 'local',
-          classification: 'Eagle'
+          term: {
+            pref_label: 'Hippogriff',
+            alt_label: ['Hippogryph'],
+            term_type: 'local',
+            classification: 'Eagle'
+          }
         }
       end
 
@@ -130,12 +138,14 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
       it 'returns newly created term in json' do
         expect(response.body).to be_json_eql(%(
           {
-            "pref_label": "Hippogriff",
-            "alt_label": ["Hippogryph"],
-            "term_type": "local",
-            "authority": null,
-            "classification": "Eagle",
-            "harry_potter_reference": null
+            "term": {
+              "pref_label": "Hippogriff",
+              "alt_label": ["Hippogryph"],
+              "term_type": "local",
+              "authority": null,
+              "classification": "Eagle",
+              "harry_potter_reference": null
+            }
           }
         )).excluding('uri', 'uuid')
       end
@@ -148,8 +158,10 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
     context 'when successfully creating a new temporary term' do
       before do
         post_with_auth '/api/v1/vocabularies/mythical_creatures/terms', params: {
-          pref_label: 'Hippogriff',
-          term_type: 'temporary',
+          term: {
+            pref_label: 'Hippogriff',
+            term_type: 'temporary',
+          }
         }
       end
 
@@ -162,12 +174,14 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
       it 'return newly created term in json' do
         expect(response.body).to be_json_eql(%(
           {
-            "pref_label": "Hippogriff",
-            "alt_label": [],
-            "authority": null,
-            "term_type": "temporary",
-            "harry_potter_reference": null,
-            "classification": null
+            "term": {
+              "pref_label": "Hippogriff",
+              "alt_label": [],
+              "authority": null,
+              "term_type": "temporary",
+              "harry_potter_reference": null,
+              "classification": null
+            }
           }
         )).excluding('uri', 'uuid')
       end
@@ -180,10 +194,12 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
     context 'when uri is missing for external term' do
       before do
         post_with_auth '/api/v1/vocabularies/mythical_creatures/terms', params: {
-          pref_label: 'Minotaur (Greek mythological character)',
-          authority: 'fast',
-          term_type: 'external',
-          harry_potter_reference: false
+          term: {
+            pref_label: 'Minotaur (Greek mythological character)',
+            authority: 'fast',
+            term_type: 'external',
+            harry_potter_reference: false
+          }
         }
       end
 
@@ -206,10 +222,12 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
       before do
         FactoryBot.create(:external_term, vocabulary: vocabulary)
         post_with_auth '/api/v1/vocabularies/mythical_creatures/terms', params: {
-          pref_label: 'Unicorn',
-          uri: 'http://id.worldcat.org/fast/1161301/',
-          authority: 'fast',
-          term_type: 'external'
+          term: {
+            pref_label: 'Unicorn',
+            uri: 'http://id.worldcat.org/fast/1161301/',
+            authority: 'fast',
+            term_type: 'external'
+          }
         }
       end
 
@@ -228,8 +246,10 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
       before do
         FactoryBot.create(:temp_term, vocabulary: vocabulary)
         post_with_auth '/api/v1/vocabularies/mythical_creatures/terms', params: {
-          pref_label: 'Yeti',
-          term_type: 'temporary'
+          term: {
+            pref_label: 'Yeti',
+            term_type: 'temporary'
+          }
         }
       end
 
@@ -257,7 +277,7 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
 
       before do
         patch_with_auth "/api/v1/vocabularies/mythical_creatures/terms/#{CGI.escape(term.uri)}", params: {
-          alt_label: ['Uni']
+          term: { alt_label: ['Uni'] }
         }
       end
 
@@ -274,13 +294,15 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
       it 'returns updated term' do
         expect(response.body).to be_json_eql(%(
           {
-            "uri": "http://id.worldcat.org/fast/1161301/",
-            "pref_label": "Unicorns",
-            "alt_label": ["Uni"],
-            "authority": "fast",
-            "term_type": "external",
-            "harry_potter_reference": null,
-            "classification": "Horses"
+            "term": {
+              "uri": "http://id.worldcat.org/fast/1161301/",
+              "pref_label": "Unicorns",
+              "alt_label": ["Uni"],
+              "authority": "fast",
+              "term_type": "external",
+              "harry_potter_reference": null,
+              "classification": "Horses"
+            }
           }
         )).excluding('uuid')
       end
@@ -295,7 +317,7 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
 
       before do
         patch_with_auth "/api/v1/vocabularies/mythical_creatures/terms/#{CGI.escape(term.uri)}", params: {
-          term_type: 'local'
+          term: { term_type: 'local' }
         }
       end
 
@@ -312,7 +334,7 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
     context 'when attempting to update a uri that is not associated with a known term' do
       before do
         patch_with_auth "/api/v1/vocabularies/mythical_creatures/terms/#{CGI.escape('https://example.com/not/known')}", params: {
-          pref_label: 'New Label'
+          term: { pref_label: 'New Label' }
         }
       end
 

--- a/spec/requests/v1/term_crud_spec.rb
+++ b/spec/requests/v1/term_crud_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
             "term": {
               "uri": "http://id.worldcat.org/fast/1161301/",
               "pref_label": "Unicorns",
-              "alt_label": [],
+              "alt_labels": [],
               "authority": "fast",
               "term_type": "external",
               "classification": "Horse",
@@ -101,7 +101,7 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
           {
             "term": {
               "pref_label": "Minotaur (Greek mythological character)",
-              "alt_label": [],
+              "alt_labels": [],
               "uri": "http://id.worldcat.org/fast/1023481",
               "authority": "fast",
               "term_type": "external",
@@ -122,7 +122,7 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
         post_with_auth '/api/v1/vocabularies/mythical_creatures/terms', params: {
           term: {
             pref_label: 'Hippogriff',
-            alt_label: ['Hippogryph'],
+            alt_labels: ['Hippogryph'],
             term_type: 'local',
             classification: 'Eagle'
           }
@@ -132,7 +132,7 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
       it 'creates a term record' do
         expect(Term.count).to be 1
         expect(Term.first.uri).not_to be_blank
-        expect(Term.first.alt_label.first).to eql 'Hippogryph'
+        expect(Term.first.alt_labels.first).to eql 'Hippogryph'
       end
 
       it 'returns newly created term in json' do
@@ -140,7 +140,7 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
           {
             "term": {
               "pref_label": "Hippogriff",
-              "alt_label": ["Hippogryph"],
+              "alt_labels": ["Hippogryph"],
               "term_type": "local",
               "authority": null,
               "classification": "Eagle",
@@ -176,7 +176,7 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
           {
             "term": {
               "pref_label": "Hippogriff",
-              "alt_label": [],
+              "alt_labels": [],
               "authority": null,
               "term_type": "temporary",
               "harry_potter_reference": null,
@@ -268,7 +268,7 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
   describe 'PATCH /api/v1/vocabularies/:string_key/terms/:uri' do
     include_context 'authentication required', 'patch', '/api/v1/vocabularies/mythical_creatures/terms/http%3A%2F%2Fid.worldcat.org%2Ffast%2F1161301%2F'
 
-    context 'when updating alt_label' do
+    context 'when updating alt_labels' do
       let(:term) do
         FactoryBot.create(:external_term,
                           vocabulary: vocabulary,
@@ -277,13 +277,13 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
 
       before do
         patch_with_auth "/api/v1/vocabularies/mythical_creatures/terms/#{CGI.escape(term.uri)}", params: {
-          term: { alt_label: ['Uni'] }
+          term: { alt_labels: ['Uni'] }
         }
       end
 
       it 'updates alt_labels for term' do
         term.reload
-        expect(term.alt_label).to contain_exactly 'Uni'
+        expect(term.alt_labels).to contain_exactly 'Uni'
       end
 
       it 'preserves custom fields' do
@@ -297,7 +297,7 @@ RSpec.describe 'CRUD /api/v1/vocabularies/:string_key/terms', type: :request do
             "term": {
               "uri": "http://id.worldcat.org/fast/1161301/",
               "pref_label": "Unicorns",
-              "alt_label": ["Uni"],
+              "alt_labels": ["Uni"],
               "authority": "fast",
               "term_type": "external",
               "harry_potter_reference": null,

--- a/spec/requests/v1/term_filtering_spec.rb
+++ b/spec/requests/v1/term_filtering_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Filtering terms', type: :request do
     it 'contains external term' do
       expect(response.body).to include_json(
         {
-          'alt_label' => ['Uni'], 'authority' => 'fast',
+          'alt_labels' => ['Uni'], 'authority' => 'fast',
           'harry_potter_reference' => true,
           'pref_label' => 'Unicorns', 'term_type' => 'external',
           'uri' => 'http://id.worldcat.org/fast/1161301/',
@@ -18,7 +18,7 @@ RSpec.describe 'Filtering terms', type: :request do
     it 'contains local term' do
       expect(response.body).to include_json(
         {
-          'alt_label' => [],
+          'alt_labels' => [],
           'authority' => nil,
           'harry_potter_reference' => true,
           'pref_label' => 'Dragons',
@@ -32,7 +32,7 @@ RSpec.describe 'Filtering terms', type: :request do
     it 'contains temp term' do
       expect(response.body).to include_json(
         {
-          'alt_label' => [],
+          'alt_labels' => [],
           'authority' => nil,
           'harry_potter_reference' => false,
           'pref_label' => 'Yeti',
@@ -53,7 +53,7 @@ RSpec.describe 'Filtering terms', type: :request do
   end
 
   before do
-    unicorn = FactoryBot.create(:external_term, alt_label: ['Uni'])
+    unicorn = FactoryBot.create(:external_term, alt_labels: ['Uni'])
     FactoryBot.create(:local_term, vocabulary: unicorn.vocabulary)
     FactoryBot.create(:temp_term, vocabulary: unicorn.vocabulary)
   end
@@ -109,12 +109,12 @@ RSpec.describe 'Filtering terms', type: :request do
     end
   end
 
-  context 'by exact alt_label' do
+  context 'by exact alt_labels' do
     include_context 'json contains external term'
     include_context 'json includes pagination', 1, 20, 1
 
     before do
-      get_with_auth '/api/v1/vocabularies/mythical_creatures/terms?alt_label=Uni'
+      get_with_auth '/api/v1/vocabularies/mythical_creatures/terms?alt_labels=Uni'
     end
   end
 

--- a/spec/requests/v1/term_pagination_spec.rb
+++ b/spec/requests/v1/term_pagination_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Term Pagination', type: :request do
 
   before do
     (1..10).each do
-      FactoryBot.create(:temp_term, vocabulary: vocab, pref_label: Faker::HarryPotter.unique.spell, custom_fields: {}, alt_label: [])
+      FactoryBot.create(:temp_term, vocabulary: vocab, pref_label: Faker::HarryPotter.unique.spell, custom_fields: {}, alt_labels: [])
     end
     Faker::HarryPotter.unique.clear
   end

--- a/spec/requests/v1/term_query_spec.rb
+++ b/spec/requests/v1/term_query_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Querying terms', type: :request do
     term = FactoryBot.create(:external_term, vocabulary: vocabulary, pref_label: 'Me', alt_label: [])
     FactoryBot.create(:external_term, vocabulary: vocabulary, pref_label: 'Meadows', alt_label: [], uri: 'http://id.worldcat.org/fast/1013121')
 
-    expected_results = [URIService::JSON.term(term)].to_json
+    expected_results = [URIService::JSON.term(term, request: false)].to_json
 
     get_with_auth '/api/v1/vocabularies/mythical_creatures/terms?q=me'
     expect(response.body).to be_json_eql(expected_results).at_path('terms')
@@ -23,7 +23,7 @@ RSpec.describe 'Querying terms', type: :request do
     term = FactoryBot.create(:local_term, vocabulary: vocabulary, pref_label: 'I', alt_label: [])
     FactoryBot.create(:local_term, vocabulary: vocabulary, pref_label: 'III', alt_label: [])
 
-    expected_search_results = [URIService::JSON.term(term)].to_json
+    expected_search_results = [URIService::JSON.term(term, request: false)].to_json
 
     get_with_auth '/api/v1/vocabularies/mythical_creatures/terms?q=i'
     expect(response.body).to be_json_eql(expected_search_results).at_path('terms')
@@ -32,7 +32,7 @@ RSpec.describe 'Querying terms', type: :request do
   context 'when querying with partial and complete queries' do
     let(:term) { FactoryBot.create(:local_term, pref_label: 'What a great value') }
     let(:expected_results) do
-      [URIService::JSON.term(term)].to_json
+      [URIService::JSON.term(term, request: false)].to_json
     end
 
     before { term }
@@ -74,7 +74,7 @@ RSpec.describe 'Querying terms', type: :request do
     term3 = FactoryBot.create(:local_term, pref_label: 'Catastrophic', uri: 'http://id.loc.gov/fake/333', vocabulary: vocabulary)
 
     expected_results = [
-      URIService::JSON.term(term1), URIService::JSON.term(term2), URIService::JSON.term(term3)
+      URIService::JSON.term(term1, request: false), URIService::JSON.term(term2, request: false), URIService::JSON.term(term3, request: false)
     ].to_json
 
     get_with_auth '/api/v1/vocabularies/mythical_creatures/terms?q=Cat'
@@ -87,7 +87,7 @@ RSpec.describe 'Querying terms', type: :request do
     term3 = FactoryBot.create(:local_term, pref_label: 'The Cat', uri: 'http://id.loc.gov/fake/333', vocabulary: vocabulary)
 
     expected_results = [
-      URIService::JSON.term(term3), URIService::JSON.term(term1), URIService::JSON.term(term2)
+      URIService::JSON.term(term3, request: false), URIService::JSON.term(term1, request: false), URIService::JSON.term(term2, request: false)
     ].to_json
 
     get_with_auth '/api/v1/vocabularies/mythical_creatures/terms?q=Cat'
@@ -100,7 +100,7 @@ RSpec.describe 'Querying terms', type: :request do
     term3 = FactoryBot.create(:local_term, pref_label: 'Steve Lobs', uri: 'http://id.loc.gov/fake/333', vocabulary: vocabulary)
 
     expected_results = [
-      URIService::JSON.term(term1), URIService::JSON.term(term2), URIService::JSON.term(term3)
+      URIService::JSON.term(term1, request: false), URIService::JSON.term(term2, request: false), URIService::JSON.term(term3, request: false)
     ].to_json
 
     get_with_auth '/api/v1/vocabularies/mythical_creatures/terms?q=Steve'
@@ -112,7 +112,7 @@ RSpec.describe 'Querying terms', type: :request do
     term2 = FactoryBot.create(:local_term, pref_label: 'Batmanners', uri: 'http://id.loc.gov/fake/222', vocabulary: vocabulary)
 
     expected_results = [
-      URIService::JSON.term(term2), URIService::JSON.term(term1)
+      URIService::JSON.term(term2, request: false), URIService::JSON.term(term1, request: false)
     ].to_json
 
     get_with_auth '/api/v1/vocabularies/mythical_creatures/terms?q=man'
@@ -123,7 +123,7 @@ RSpec.describe 'Querying terms', type: :request do
     term1 = FactoryBot.create(:local_term, pref_label: 'Batmanners', uri: 'http://id.loc.gov/fake/222', vocabulary: vocabulary)
     term2 = FactoryBot.create(:local_term, pref_label: 'Supermanners', uri: 'http://id.loc.gov/fake/111', vocabulary: vocabulary)
 
-    expected_results = [URIService::JSON.term(term1)].to_json
+    expected_results = [URIService::JSON.term(term1, request: false)].to_json
 
     get_with_auth '/api/v1/vocabularies/mythical_creatures/terms?q=bat'
     expect(response.body).to be_json_eql(expected_results).at_path('terms')
@@ -133,7 +133,7 @@ RSpec.describe 'Querying terms', type: :request do
   it 'performs a case insensitive search' do
     term = FactoryBot.create(:local_term, pref_label: 'Batmanners', uri: 'http://id.loc.gov/fake/222', vocabulary: vocabulary)
 
-    expected_results = [URIService::JSON.term(term) ].to_json
+    expected_results = [URIService::JSON.term(term, request: false)].to_json
 
     get_with_auth '/api/v1/vocabularies/mythical_creatures/terms?q=bAtMaNnErS'
     expect(response.body).to be_json_eql(expected_results).at_path('terms')

--- a/spec/requests/v1/term_query_spec.rb
+++ b/spec/requests/v1/term_query_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe 'Querying terms', type: :request do
   end
 
   it 'for 2 character queries only returns results with exact matches' do
-    term = FactoryBot.create(:external_term, vocabulary: vocabulary, pref_label: 'Me', alt_label: [])
-    FactoryBot.create(:external_term, vocabulary: vocabulary, pref_label: 'Meadows', alt_label: [], uri: 'http://id.worldcat.org/fast/1013121')
+    term = FactoryBot.create(:external_term, vocabulary: vocabulary, pref_label: 'Me', alt_labels: [])
+    FactoryBot.create(:external_term, vocabulary: vocabulary, pref_label: 'Meadows', alt_labels: [], uri: 'http://id.worldcat.org/fast/1013121')
 
     expected_results = [URIService::JSON.term(term, request: false)].to_json
 
@@ -20,8 +20,8 @@ RSpec.describe 'Querying terms', type: :request do
   end
 
   it 'for 1 character queries only returns results with exact matches' do
-    term = FactoryBot.create(:local_term, vocabulary: vocabulary, pref_label: 'I', alt_label: [])
-    FactoryBot.create(:local_term, vocabulary: vocabulary, pref_label: 'III', alt_label: [])
+    term = FactoryBot.create(:local_term, vocabulary: vocabulary, pref_label: 'I', alt_labels: [])
+    FactoryBot.create(:local_term, vocabulary: vocabulary, pref_label: 'III', alt_labels: [])
 
     expected_search_results = [URIService::JSON.term(term, request: false)].to_json
 

--- a/spec/requests/v1/vocabularies_spec.rb
+++ b/spec/requests/v1/vocabularies_spec.rb
@@ -51,13 +51,21 @@ RSpec.describe '/api/v1/vocabularies', type: :request do
 
     it 'returns one vocabulary' do
       get_with_auth '/api/v1/vocabularies/mythical_creatures'
-      expect(JSON.parse(response.body)).to match('string_key' => 'mythical_creatures', 'label' => 'Mythical Creatures', 'custom_fields' => {})
+      expect(response.body).to be_json_eql(%(
+        {
+          "vocabulary": {
+            "string_key": "mythical_creatures",
+            "label": "Mythical Creatures",
+            "custom_fields": {}
+          }
+        }
+      ))
       expect(response.status).to be 200
     end
 
     it 'returns 404 if vocabulary not found' do
       get_with_auth '/api/v1/vocabularies/not_created_yet'
-      expect(JSON.parse(response.body)).to match('errors' => [{ 'title' => 'Not Found' }])
+      expect(response.body).to be_json_eql(%({ "errors": [{ "title": "Not Found" }] }))
       expect(response.status).to be 404
     end
   end
@@ -67,7 +75,7 @@ RSpec.describe '/api/v1/vocabularies', type: :request do
 
     context 'when successfully creating a new vocabulary' do
       before do
-        post_with_auth '/api/v1/vocabularies', params: { string_key: 'collections', label: 'Collections' }
+        post_with_auth '/api/v1/vocabularies', params: { vocabulary: { string_key: 'collections', label: 'Collections' } }
       end
 
       it 'creates a new vocabulary record' do
@@ -76,11 +84,15 @@ RSpec.describe '/api/v1/vocabularies', type: :request do
       end
 
       it 'returns newly created vocabulary in json' do
-        expect(JSON.parse(response.body)).to match(
-          'string_key' => 'collections',
-          'label' => 'Collections',
-          'custom_fields' => {}
-        )
+        expect(response.body).to be_json_eql(%(
+          {
+            "vocabulary": {
+              "string_key": "collections",
+              "label": "Collections",
+              "custom_fields": {}
+            }
+          }
+        ))
       end
 
       it 'returns 201' do
@@ -90,7 +102,7 @@ RSpec.describe '/api/v1/vocabularies', type: :request do
 
     context 'when string_key is missing' do
       before do
-        post_with_auth '/api/v1/vocabularies', params: { string_key: nil, label: 'Collections' }
+        post_with_auth '/api/v1/vocabularies', params: { vocabulary: { string_key: nil, label: 'Collections' } }
       end
 
       it 'returns 400' do
@@ -112,7 +124,7 @@ RSpec.describe '/api/v1/vocabularies', type: :request do
     context 'when creating a vocabulary that already exisits' do
       before do
         FactoryBot.create(:vocabulary)
-        post_with_auth '/api/v1/vocabularies', params: { string_key: 'mythical_creatures', label: 'Mythical Creatures' }
+        post_with_auth '/api/v1/vocabularies', params: { vocabulary: { string_key: 'mythical_creatures', label: 'Mythical Creatures' } }
       end
 
       it 'returns 409' do
@@ -134,7 +146,7 @@ RSpec.describe '/api/v1/vocabularies', type: :request do
 
     context 'when updating label' do
       before do
-        patch_with_auth '/api/v1/vocabularies/mythical_creatures', params: { label: 'FAST Mythical Creatures' }
+        patch_with_auth '/api/v1/vocabularies/mythical_creatures', params: { vocabulary: { label: 'FAST Mythical Creatures' } }
       end
 
       it 'updates label for vocabulary' do
@@ -142,7 +154,15 @@ RSpec.describe '/api/v1/vocabularies', type: :request do
       end
 
       it 'returns new vocabulary' do
-        expect(JSON.parse(response.body)).to match('string_key' => 'mythical_creatures', 'label' => 'FAST Mythical Creatures', 'custom_fields' => {})
+        expect(response.body).to be_json_eql(%(
+          {
+            "vocabulary": {
+              "string_key": "mythical_creatures",
+              "label": "FAST Mythical Creatures",
+              "custom_fields": {}
+            }
+          }
+        ))
       end
 
       it 'returns 200' do
@@ -152,11 +172,19 @@ RSpec.describe '/api/v1/vocabularies', type: :request do
 
     context 'when updating string key' do
       before do
-        patch_with_auth '/api/v1/vocabularies/mythical_creatures', params: { string_key: 'fast_mythical_creatures' }
+        patch_with_auth '/api/v1/vocabularies/mythical_creatures', params: { vocabulary: { string_key: 'fast_mythical_creatures' } }
       end
 
       it 'does not update record' do
-        expect(JSON.parse(response.body)).to match('string_key' => 'mythical_creatures', 'label' => 'Mythical Creatures', 'custom_fields' => {})
+        expect(response.body).to be_json_eql(%(
+          {
+            "vocabulary": {
+              "string_key": "mythical_creatures",
+              "label": "Mythical Creatures",
+              "custom_fields": {}
+            }
+          }
+        ))
       end
 
       # not sure if this is the correct reponse code.
@@ -167,7 +195,7 @@ RSpec.describe '/api/v1/vocabularies', type: :request do
 
     context 'when invalid string key' do
       before do
-        patch_with_auth '/api/v1/vocabularies/names', params: { label: 'FAST Names' }
+        patch_with_auth '/api/v1/vocabularies/names', params: { vocabulary: { label: 'FAST Names' } }
       end
 
       it 'returns 404' do


### PR DESCRIPTION
- Renaming alt_label to alt_labels
- term, custom field and vocabulary responses will be nested under the model
- request for field updates for term, custom field and vocabulary responses must be nested under the model name

Note: Solr configuration needs to be updated when these changes roll out